### PR TITLE
Fixed page numbering to match 2021 style guide

### DIFF
--- a/latex_files/uothesis.cls
+++ b/latex_files/uothesis.cls
@@ -574,7 +574,7 @@ All rights reserved.
 }
 
 \def\@maketitlepages{
-  \pagenumbering{roman}
+  \pagenumbering{arabic}
   \@maketitlepage
   \if@approved
     \@makeapprovepage
@@ -654,7 +654,7 @@ Draft of \@longdraftdate\\
         \@maketitlepages
       \else
         \@makedraftcover
-        \pagenumbering{roman}
+        \pagenumbering{arabic}
         \listoftodos \clearpage
         \@tableofcontents
         \ifnofigures\else
@@ -674,8 +674,6 @@ Draft of \@longdraftdate\\
   \fi
   \pagestyle{plain}
   \ifjustified\else\RaggedRight\fi
-  \pagenumbering{arabic}
-  \setcounter{page}{1}
 }
 
 \def\@footlines#1{\hbox to\textwidth{#1}}


### PR DESCRIPTION
Change the prefatory page numbering style from `roman` to `arabic` and continue counting pages after Chapter 1 instead of restarting the page counter. Matches the [2021 style guide](https://graduatestudies.uoregon.edu/sites/graduatestudies1.uoregon.edu/files/style-manual-2021.pdf). Fixes issue #11.