### PR TITLE
Reflect 2023 formatting guidance for prefatory pages

### DIFF
--- a/latex_files/cover.tex
+++ b/latex_files/cover.tex
@@ -9,7 +9,6 @@
 \degreemonth{December}
 \degreeyear{2021}
 \chair{Albus Dumbledore}
-\committee{Minerva McGonagall    & Core Member \\
-           Severus Snape    & Core Member \\
-           Sirius Black & Institutional Representative \\}
-\graddean{Andy Karduna & Interim Vice Provost for Graduate Studies}
+\committee{Minerva McGonagall, Core Member \\
+           Severus Snape, Core Member \\
+           Sirius Black, Institutional Representative \\}

--- a/latex_files/cover.tex
+++ b/latex_files/cover.tex
@@ -2,7 +2,8 @@
 \covertitle{The Main Title of the Dissertation: The Subtitle of the Dissertation}
 \abstracttitle{The Main Title of the Dissertation: The Subtitle of the Dissertation}
 \author{Hermione Granger}
-\department{Department of Psychology}
+\major{Psychology}
+\department{Department of Psychology} % CM: the department-related commands may be unused after the 2023 guidance regarding title page.
 \narrowdepartment{Department of Psychology}
 \degreetype{Master of Philosophy}
 \degreemonth{December}

--- a/latex_files/cover.tex
+++ b/latex_files/cover.tex
@@ -9,6 +9,10 @@
 \degreemonth{December}
 \degreeyear{2021}
 \chair{Albus Dumbledore}
-\committee{Minerva McGonagall, Core Member \\
-           Severus Snape, Core Member \\
-           Sirius Black, Institutional Representative \\}
+\cochair{Minerva McGonagall}
+% Or, if you have two equal co-chairs or some other non-standard situation:
+% \cochairs{Albus Dumbledore, Co-Chair \\*
+%           Minerva McGonagall, Co-Chair \\*}
+\committee{Severus Snape, Core Member \\*
+           Pomona Sprout, Core Member \\*
+           Sirius Black, Institutional Representative \\*}

--- a/latex_files/uothesis.cls
+++ b/latex_files/uothesis.cls
@@ -246,12 +246,19 @@ of this document.}
 \def\department#1{\gdef\@department{#1}}
 \def\narrowdepartment#1{\gdef\@narrowdepartment{#1}}
 
+\def\major#1{\gdef\@major{#1}}
+
+
 \def\chair#1{\gdef\@chair{#1}}
+
 \newif\if@cochair
-%\if@dissertation % Commented out by JL since mstheses *can* have committees, too, according to the current UOregon Style Guide.
-  \def\cochair#1{\gdef\@cochair{#1}\@cochairtrue}
-  \def\committee#1{\gdef\@committee{#1}}
-%\fi
+\def\cochair#1{\gdef\@cochair{#1}\@cochairtrue}
+
+% CM: I needed two equal co-chairs instead of one chair and one co-chair so I added this command which basically is just a pass-through (see later)
+\newif\if@cochairs
+\def\cochairs#1{\gdef\@cochairs{#1}\@cochairstrue}
+
+\def\committee#1{\gdef\@committee{#1}}
 \def\graddean#1{\gdef\@graddean{#1}}
 
 \def\degreetype#1{\gdef\@degree{#1}}
@@ -369,54 +376,38 @@ of this document.}
   \begin{center}
   \vspace*{0.25in}
   \doublespacing
-  \@uppercovertitle
+  \@covertitle
   \singlespacing
   \vfill
   by \\*[\baselineskip]
-  \@upperauthor\\
+  \@author\\
   \vfil
   \ifdraft\@disclaimer\\\fi\vfill
-   A \@upperpapertype \\*[\baselineskip]
-   Presented to the  \@narrowdepartment \\*
-   and the Division of Graduate Studies of the University of Oregon \\*
-   in partial fulfillment of the requirements \\*
-   for the degree of \\*
-   \@degree \\*[\baselineskip]
+  \doublespacing
+   A \@papertype\ accepted and approved in partial fulfillment of the \\
+   requirements for the degree of \\*
+   \@degree \\
+   in\ \@major \\*[\baselineskip] \\
+
+   Dissertation Committee: \\
+   \if@cochairs
+     \@cochairs\\
+   \else
+     \@chair , Chair\\
+     \if@cochair
+       \@cochair , Co-chair\\
+     \fi
+   \fi
+   \if@lackscommittee
+     % If we don't have a committee, do nothing. Otherwise, render the committee. Rather, just enter a few blank lines.
+     \\ \\
+   \else
+     \@committee\\ \\
+   \fi \\
+   \vfill
+   University of Oregon \\
    \@degreemonth ~\thedegreeyear\\
    \end{center}
-}
-
-\def\@makeapprovepage{
-  \clearpage
-  \thispagestyle{plain}
-  \raggedright
-  \@startchapter{\@upperpapertype\ APPROVAL PAGE}
-  \begin{spacing}{1}
-    \vspace*{3ex}
-    \noindent
-    Student: \@author\\*[\baselineskip]
-    Title: \@abstracttitle\\*[\baselineskip]
-    This \@papertype\ has been accepted and approved
-     in partial fulfillment of the requirements for the
-    \@degree\ degree in the \@narrowdepartment\ by:\\*[\baselineskip]
-    \begin{tabular}[t]{@{}p{2.25in} p{3.25in}}
-      \@chair & Chair\\
-      \if@cochair
-        \@cochair& Co-chair\\
-      \fi
-      \if@lackscommittee
-        % If we don't have a committee, do nothing. Otherwise, render the committee. Rather, just enter a few blank lines.
-        \\ \\
-      \else
-        \@committee\\ \\
-      \fi
-      and & \\ \\
-      \@graddean
-    \end{tabular}\\*[\baselineskip]
-    Original approval signatures are on file with the
-    University of Oregon Division of Graduate Studies.\\*[\baselineskip]
-    Degree awarded \@degreemonth ~\thedegreeyear
-  \end{spacing}
 }
 
 \def\@makecopyrightpage{
@@ -468,9 +459,7 @@ All rights reserved.
     \vspace*{3ex}
     \noindent
     \@author\\*[\baselineskip]
-    \@degree\\*[\baselineskip]
-    \@department\\*[\baselineskip]
-    \@degreemonth ~\thedegreeyear\\*[\baselineskip]
+    \@degree\ in\ \@major \\*[\baselineskip]
     Title: \@abstracttitle\\*[\baselineskip]
     %\\*[2\baselineskip]
   \end{spacing}

--- a/latex_files/uothesis.cls
+++ b/latex_files/uothesis.cls
@@ -380,32 +380,31 @@ of this document.}
   \singlespacing
   \vfill
   by \\*[\baselineskip]
-  \@author\\
+  \@author\\*
   \vfil
   \ifdraft\@disclaimer\\\fi\vfill
   \doublespacing
-   A \@papertype\ accepted and approved in partial fulfillment of the \\
+   A \@papertype\ accepted and approved in partial fulfillment of the \\*
    requirements for the degree of \\*
-   \@degree \\
-   in\ \@major \\*[\baselineskip] \\
+   \@degree \\*
+   in \@major \\*[\baselineskip]
 
-   Dissertation Committee: \\
+   Dissertation Committee:\\*
    \if@cochairs
-     \@cochairs\\
+     \@cochairs
    \else
-     \@chair , Chair\\
+     \@chair, Chair\\*
      \if@cochair
-       \@cochair , Co-chair\\
+       \@cochair, Co-chair\\*
      \fi
    \fi
    \if@lackscommittee
      % If we don't have a committee, do nothing. Otherwise, render the committee. Rather, just enter a few blank lines.
-     \\ \\
    \else
-     \@committee\\ \\
-   \fi \\
+     \@committee
+   \fi
    \vfill
-   University of Oregon \\
+   University of Oregon \\*
    \@degreemonth ~\thedegreeyear\\
    \end{center}
 }
@@ -459,7 +458,7 @@ All rights reserved.
     \vspace*{3ex}
     \noindent
     \@author\\*[\baselineskip]
-    \@degree\ in\ \@major \\*[\baselineskip]
+    \@degree\ in \@major \\*[\baselineskip]
     Title: \@abstracttitle\\*[\baselineskip]
     %\\*[2\baselineskip]
   \end{spacing}
@@ -565,9 +564,6 @@ All rights reserved.
 \def\@maketitlepages{
   \pagenumbering{arabic}
   \@maketitlepage
-  \if@approved
-    \@makeapprovepage
-  \fi
   \@makecopyrightpage
   \@makeabstractpage
   \@makevita


### PR DESCRIPTION
The [2023 guidance](https://graduatestudies.uoregon.edu/sites/default/files/2023-07/2023-style-manual.pdf) apparently made some changes to the prefatory pages which this PR tries to capture.

Also adds a \cochairs command which is a pass-through for cases like mine where two or more equal co-chairs (instead of a chair and a co-chair) are required.